### PR TITLE
Fix all Dependabot alerts; update deps to latest safe versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -525,9 +525,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -536,9 +536,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -596,9 +596,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -617,9 +617,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -730,29 +730,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/nzakas"
-            }
-        },
-        "node_modules/@isaacs/balanced-match": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/@isaacs/brace-expansion": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@isaacs/balanced-match": "^4.0.1"
-            },
-            "engines": {
-                "node": "20 || >=22"
             }
         },
         "node_modules/@isaacs/cliui": {
@@ -895,9 +872,9 @@
             }
         },
         "node_modules/@sinonjs/fake-timers": {
-            "version": "13.0.5",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
-            "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+            "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -905,9 +882,9 @@
             }
         },
         "node_modules/@sinonjs/samsam": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
-            "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-10.0.2.tgz",
+            "integrity": "sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -1605,9 +1582,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1641,9 +1618,9 @@
             }
         },
         "node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -1758,9 +1735,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2214,9 +2191,9 @@
             "license": "MIT"
         },
         "node_modules/diff": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-            "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+            "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -2424,9 +2401,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2471,9 +2448,9 @@
             }
         },
         "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2610,9 +2587,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+            "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
             "dev": true,
             "funding": [
                 {
@@ -2705,9 +2682,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
@@ -2818,17 +2795,40 @@
             "license": "BSD-2-Clause",
             "peer": true
         },
+        "node_modules/glob/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/glob/node_modules/brace-expansion": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "@isaacs/brace-expansion": "^5.0.0"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -3048,6 +3048,16 @@
                 "node": ">=0.12.0"
             }
         },
+        "node_modules/is-path-inside": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-plain-obj": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -3187,10 +3197,20 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -3434,13 +3454,13 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -3460,9 +3480,9 @@
             }
         },
         "node_modules/mocha": {
-            "version": "11.7.1",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.1.tgz",
-            "integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
+            "version": "11.7.6",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+            "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3474,6 +3494,7 @@
                 "find-up": "^5.0.0",
                 "glob": "^10.4.5",
                 "he": "^1.2.0",
+                "is-path-inside": "^3.0.3",
                 "js-yaml": "^4.1.0",
                 "log-symbols": "^4.1.0",
                 "minimatch": "^9.0.5",
@@ -3915,9 +3936,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3974,16 +3995,6 @@
                 }
             ],
             "license": "MIT"
-        },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
         },
         "node_modules/readable-stream": {
             "version": "2.3.8",
@@ -4126,9 +4137,9 @@
             }
         },
         "node_modules/schema-utils/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -4179,13 +4190,13 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+            "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/setimmediate": {
@@ -4232,34 +4243,20 @@
             }
         },
         "node_modules/sinon": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.0.tgz",
-            "integrity": "sha512-TOgRcwFPbfGtpqvZw+hyqJDvqfapr1qUlOizROIk4bBLjlsjlB00Pg6wMFXNtJRpu+eCZuVOaLatG7M8105kAw==",
+            "version": "21.1.2",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.1.2.tgz",
+            "integrity": "sha512-FS6mN+/bx7e2ajpXkEmOcWB6xBzWiuNoAQT18/+a20SS4U7FSYl8Ms7N6VTUxN/1JAjkx7aXp+THMC8xdpp0gA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@sinonjs/commons": "^3.0.1",
-                "@sinonjs/fake-timers": "^13.0.5",
-                "@sinonjs/samsam": "^8.0.1",
-                "diff": "^7.0.0",
-                "supports-color": "^7.2.0"
+                "@sinonjs/fake-timers": "^15.3.2",
+                "@sinonjs/samsam": "^10.0.2",
+                "diff": "^8.0.4"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/sinon"
-            }
-        },
-        "node_modules/sinon/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/source-map": {
@@ -4483,9 +4480,9 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.16",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-            "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+            "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -4493,7 +4490,6 @@
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^4.3.0",
-                "serialize-javascript": "^6.0.2",
                 "terser": "^5.31.1"
             },
             "engines": {
@@ -4507,10 +4503,37 @@
                 "webpack": "^5.1.0"
             },
             "peerDependenciesMeta": {
+                "@minify-html/node": {
+                    "optional": true
+                },
                 "@swc/core": {
                     "optional": true
                 },
+                "@swc/css": {
+                    "optional": true
+                },
+                "@swc/html": {
+                    "optional": true
+                },
+                "clean-css": {
+                    "optional": true
+                },
+                "cssnano": {
+                    "optional": true
+                },
+                "csso": {
+                    "optional": true
+                },
                 "esbuild": {
+                    "optional": true
+                },
+                "html-minifier-terser": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "postcss": {
                     "optional": true
                 },
                 "uglify-js": {
@@ -4534,9 +4557,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4567,9 +4590,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -122,5 +122,9 @@
         "sinon": "^21.0.0",
         "ts-loader": "^9.5.2",
         "typescript": "^5.9.2"
+    },
+    "overrides": {
+        "serialize-javascript": "7.0.7",
+        "diff": "8.0.4"
     }
 }


### PR DESCRIPTION
## Summary

Resolves **all** open Dependabot alerts and `npm audit` findings — **0 vulnerabilities remaining**. Combines the four open Dependabot PRs plus the alerts they didn't cover into one reviewed change.

### Fixes (by severity)
| Package | Change | Advisory |
|---|---|---|
| serialize-javascript | → 7.0.7 (override) | RCE via RegExp.flags, CPU-exhaustion DoS (**high**) |
| fast-uri | 3.1.0 → 3.1.3 | host confusion + path traversal (**high** ×2) |
| flatted | 3.3.3 → 3.4.2 | prototype pollution, unbounded-recursion DoS (**high**) |
| minimatch | 3.1.2/9.0.5/10.1.1 → 3.1.5/9.0.9/10.2.5 | ReDoS (**high**) |
| diff | → 8.0.4 (override) | parsePatch/applyPatch DoS |
| js-yaml | 4.1.1 → 4.3.0 | quadratic-complexity DoS (moderate) |
| picomatch | 2.3.1 → 2.3.2 | method injection (moderate) |
| ajv / brace-expansion / @isaacs/brace-expansion | in-range bumps | ReDoS / process-hang |

### Why `overrides`
`mocha@11.7.6` (latest) still declares `serialize-javascript@^6.0.2` and `diff@^7.0.0`, both vulnerable, and no released mocha fixes them yet. Pinned via npm `overrides`; both are dev-only (mocha's reporters and diff output).

### Supply-chain diligence
Per the "nothing too new" requirement (`min-release-age=7`), **every** resolved version was verified published >7 days ago — closest is `brace-expansion@2.1.2` at 9 days. Nothing was pulled from the last week.

### Verification
- `tsc` compile ✅
- esbuild bundle ✅
- eslint ✅
- all 8 integration tests pass ✅ (run from a short path to dodge a local Unix-socket path-length limit; unaffected on CI)

### Supersedes
Combines and replaces #18 (minimatch), #19 (flatted), #20 (picomatch), #21 (fast-uri).

🤖 Generated with [Claude Code](https://claude.com/claude-code)